### PR TITLE
Tilesets now loaded correctly when opening a saved file

### DIFF
--- a/editor/src/main/java/me/manabreak/ratio/plugins/exporters/GdxJsonExporter.java
+++ b/editor/src/main/java/me/manabreak/ratio/plugins/exporters/GdxJsonExporter.java
@@ -12,6 +12,7 @@ import me.manabreak.ratio.plugins.tilesets.PaletteTileset;
 import me.manabreak.ratio.plugins.tilesets.Tileset;
 import me.manabreak.ratio.utils.TextUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +54,22 @@ public class GdxJsonExporter implements Exporter {
 
         JsonValue root = new JsonValue(JsonValue.ValueType.object);
 
+        List<Tileset> tilesets = new ArrayList<>();
+        for (TileLayer layer : level.getLayers()) {
+            for (Tileset tileset : layer.getParts().keySet()) {
+                if (!tilesets.contains(tileset)) {
+                    tilesets.add(tileset);
+                }
+            }
+        }
+
+        JsonValue tilesetsJson = new JsonValue(JsonValue.ValueType.array);
+        for (Tileset tileset : tilesets) {
+            // Tileset
+            writeTileset(tileset, tilesetsJson);
+        }
+        root.addChild("tilesets", tilesetsJson);
+
         // Level properties
         writeProperties(level, properties, root);
 
@@ -67,8 +84,8 @@ public class GdxJsonExporter implements Exporter {
             for (Tileset tileset : layer.getParts().keySet()) {
                 JsonValue jsonPart = new JsonValue(JsonValue.ValueType.object);
 
-                // Tileset
-                writeTileset(tileset, jsonPart);
+                // Index of the tileset in the tileset json portion
+                jsonPart.addChild("tileset", new JsonValue(tilesets.indexOf(tileset)));
 
                 // Tree
                 Octree<Cell> octree = layer.getParts().get(tileset);
@@ -216,6 +233,6 @@ public class GdxJsonExporter implements Exporter {
         }
         jsonTileset.addChild("tiles", tiles);
 
-        root.addChild("tileset", jsonTileset);
+        root.addChild(jsonTileset);
     }
 }

--- a/editor/src/main/java/me/manabreak/ratio/plugins/importers/GdxJsonImporter.java
+++ b/editor/src/main/java/me/manabreak/ratio/plugins/importers/GdxJsonImporter.java
@@ -50,6 +50,12 @@ public class GdxJsonImporter implements Importer {
         String json = fh.readString();
         JsonValue root = new JsonReader().parse(json);
 
+        final JsonValue tilesetsJson = root.get("tilesets");
+        for (JsonValue jsonTileset : tilesetsJson) {
+            Tileset tileset = parseTileset(fh, jsonTileset);
+            level.addTileset(tileset);
+        }
+
         final JsonValue layers = root.get("layers");
         for (JsonValue jsonLayer : layers) {
             TileLayer layer = level.createLayer(jsonLayer.getString("name"));
@@ -57,7 +63,8 @@ public class GdxJsonImporter implements Importer {
 
             JsonValue parts = jsonLayer.get("parts");
             for (JsonValue part : parts) {
-                Tileset tileset = parseTileset(fh, part.get("tileset"));
+                int tilesetIndex = part.getInt("tileset");
+                Tileset tileset = level.getTileset(tilesetIndex);
 
                 JsonValue cells = part.get("cells");
                 for (JsonValue cell : cells) {

--- a/editor/src/main/java/me/manabreak/ratio/plugins/level/Level.java
+++ b/editor/src/main/java/me/manabreak/ratio/plugins/level/Level.java
@@ -1,12 +1,31 @@
 package me.manabreak.ratio.plugins.level;
 
+import me.manabreak.ratio.plugins.tilesets.Tileset;
+
 import java.util.ArrayList;
+import java.util.List;
 
 public class Level {
+    private final ArrayList<Tileset> tilesets = new ArrayList<>();
     private final ArrayList<TileLayer> layers = new ArrayList<>();
 
     public Level() {
 
+    }
+
+    public void addTileset(Tileset tileset) {
+        this.tilesets.add(tileset);
+    }
+
+    public Tileset getTileset(int index) {
+        return tilesets.get(index);
+    }
+
+    public Tileset getTileset(String name) {
+        for (Tileset tileset : tilesets) {
+            if (tileset.getName().equals(name)) return tileset;
+        }
+        return null;
     }
 
     public TileLayer createLayer(String name) {
@@ -32,5 +51,9 @@ public class Level {
 
     public void addLayer(int i, TileLayer layer) {
         this.layers.add(i, layer);
+    }
+
+    public List<Tileset> getTilesets() {
+        return tilesets;
     }
 }

--- a/editor/src/main/java/me/manabreak/ratio/plugins/tilesets/TilesetPlugin.java
+++ b/editor/src/main/java/me/manabreak/ratio/plugins/tilesets/TilesetPlugin.java
@@ -19,5 +19,10 @@ public class TilesetPlugin extends EditorPlugin {
 
     public void levelLoaded(Level level) {
         // TODO
+        for (Tileset tileset : level.getTilesets()) {
+            ui.createTab(tileset);
+            final boolean palette = tileset instanceof PaletteTileset;
+            ui.createPicker(tileset, palette ? 1 : 16, palette ? 1 : 16);
+        }
     }
 }

--- a/editor/src/test/java/me/manabreak/ratio/plugins/exporters/GdxJsonExporterTest.java
+++ b/editor/src/test/java/me/manabreak/ratio/plugins/exporters/GdxJsonExporterTest.java
@@ -111,8 +111,20 @@ public class GdxJsonExporterTest {
         System.out.println(jsonString);
 
         JsonValue val = new JsonReader().parse(jsonString);
-        assertTrue(val.has("layers"));
 
+        assertTrue(val.has("tilesets"));
+        JsonValue tilesets = val.get("tilesets");
+        assertEquals(2, tilesets.size);
+
+        JsonValue imageTilesetPart = tilesets.get(0);
+        assertEquals("normal", imageTilesetPart.getString("type"));
+        assertEquals(2, imageTilesetPart.get("tiles").size);
+
+        JsonValue paletteTilesetPart = tilesets.get(1);
+        assertEquals("palette", paletteTilesetPart.getString("type"));
+        assertEquals(3, paletteTilesetPart.get("tiles").size);
+
+        assertTrue(val.has("layers"));
         JsonValue layers = val.get("layers");
         assertEquals(1, layers.size);
 
@@ -120,13 +132,8 @@ public class GdxJsonExporterTest {
         assertTrue(layerJson.has("parts"));
         assertEquals(2, layerJson.get("parts").size);
 
-        JsonValue imageTilesetPart = layerJson.get("parts").get(0);
-        assertEquals("normal", imageTilesetPart.get("tileset").getString("type"));
-        assertEquals(2, imageTilesetPart.get("tileset").get("tiles").size);
-
-        JsonValue paletteTilesetPart = layerJson.get("parts").get(1);
-        assertEquals("palette", paletteTilesetPart.get("tileset").getString("type"));
-        assertEquals(3, paletteTilesetPart.get("tileset").get("tiles").size);
+        assertEquals(0, layerJson.get("parts").get(0).getInt("tileset"));
+        assertEquals(1, layerJson.get("parts").get(1).getInt("tileset"));
 
         assertTrue(val.has("objects"));
         JsonValue objects = val.get("objects");


### PR DESCRIPTION
Fixed an issue where tilesets were missing when loading a saved file.

This change also changes the way the tilesets are saved in the JSON format. Now the tilesets have their own root element and the level parts refer to these with indexes.